### PR TITLE
DSE-568 Add option to skip dependency setup during oauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rumpel-react",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "private": true,
   "dependencies": {
     "@dataswift/hat-js": "^0.3.2",

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,7 +1,7 @@
 import { environment } from './environment';
 
 export const config = {
-  version: '4.0.8.0',
+  version: '4.0.9.0',
   name: environment.appName,
   tokenApp: environment.tokenName,
   tokenExpiryTime: 3,

--- a/src/features/hat-login/HatLoginBuildRedirect.tsx
+++ b/src/features/hat-login/HatLoginBuildRedirect.tsx
@@ -11,6 +11,7 @@ import {
 } from "../hmi/hmiSlice";
 import * as queryString from "query-string";
 import { addMinutes, isFuture, parseISO } from "date-fns";
+import { selectSkipDeps } from "./hatLoginSlice";
 
 type Props = {
     children: React.ReactNode;
@@ -30,6 +31,7 @@ const HatLoginBuildRedirect: React.FC<Props> = props => {
   const dependencyApps = useSelector(selectDependencyApps);
   const dependencyPlugsAreActive = useSelector(selectDependencyPlugsAreActive);
   const dependencyToolsAreEnabled = useSelector(selectDependencyToolsEnabled);
+  const skipsDeps = useSelector(selectSkipDeps);
 
   useEffect(() => {
     const buildRedirect = async (app: HatApplication) => {
@@ -88,7 +90,8 @@ const HatLoginBuildRedirect: React.FC<Props> = props => {
       }
     };
 
-    if (parentApp && parentApp.active && dependencyPlugsAreActive && dependencyToolsAreEnabled) {
+    if ((parentApp && parentApp.active) &&
+        ((dependencyPlugsAreActive && dependencyToolsAreEnabled) || skipsDeps)) {
       buildRedirect(parentApp);
       return;
     }
@@ -103,7 +106,7 @@ const HatLoginBuildRedirect: React.FC<Props> = props => {
         return;
       }
     }
-  }, [parentApp, dependencyApps, dependencyPlugsAreActive, dependencyToolsAreEnabled]);
+  }, [parentApp, dependencyApps, dependencyPlugsAreActive, dependencyToolsAreEnabled, skipsDeps]);
 
   return <>{props.children}</>;
 };

--- a/src/features/hat-login/HatLoginParamValidation.tsx
+++ b/src/features/hat-login/HatLoginParamValidation.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { getApplicationsHmi } from "../applications/applicationsSlice";
 import { useDispatch } from "react-redux";
-import { setRedirectError } from "./hatLoginSlice";
+import { setRedirectError, setSkipDeps } from "./hatLoginSlice";
 import * as queryString from "query-string";
 
 type Props = {
@@ -13,17 +13,20 @@ type Query = {
   name?: string;
   redirect_uri?: string;
   redirect?: string;
+  skip_deps?: string;
 }
 
 const HatLoginParamValidation: React.FC<Props> = props => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const { application_id, name, redirect_uri, redirect } =
+    const { application_id, name, redirect_uri, redirect, skip_deps } =
         queryString.parse(window.location.search) as Query;
     const applicationId = application_id || name;
     const applicationIdSafe = applicationId?.toLowerCase();
     const redirectParam = redirect_uri || redirect;
+
+    dispatch(setSkipDeps(skip_deps === 'true'));
 
     if (!redirectParam) {
       dispatch(setRedirectError('application_misconfigured', 'redirect_is_required '));

--- a/src/features/hat-login/HatLoginSetupDependency.tsx
+++ b/src/features/hat-login/HatLoginSetupDependency.tsx
@@ -9,6 +9,7 @@ import {
 } from "../hmi/hmiSlice";
 import * as queryString from "query-string";
 import { addMinutes, isFuture, parseISO } from "date-fns";
+import { selectSkipDeps } from "./hatLoginSlice";
 
 type Props = {
     children: React.ReactNode;
@@ -26,6 +27,7 @@ const HatLoginSetupDependency: React.FC<Props> = props => {
   const parentApp = useSelector(selectParentApp);
   const dependencyApps = useSelector(selectDependencyApps);
   const plugsAreActive = useSelector(selectDependencyPlugsAreActive);
+  const skipsDeps = useSelector(selectSkipDeps);
 
   useEffect(() => {
     const { application_id, name, redirect_uri, redirect, dependencies } =
@@ -97,7 +99,7 @@ const HatLoginSetupDependency: React.FC<Props> = props => {
       }
     }
 
-    if (parentApp && parentApp.active && !plugsAreActive) {
+    if (parentApp && parentApp.active && !plugsAreActive && !skipsDeps) {
       setupAppDependencies(dependencyApps);
     }
 

--- a/src/features/hat-login/hatLoginSlice.ts
+++ b/src/features/hat-login/hatLoginSlice.ts
@@ -5,6 +5,7 @@ import { setParentApp } from "../hmi/hmiSlice";
 
 type ApplicationsState = {
     errorMessage?: string;
+    skipDeps: boolean;
     redirectError: {
         error: string;
         errorReason: string;
@@ -13,6 +14,7 @@ type ApplicationsState = {
 
 export const initialState: ApplicationsState = {
   errorMessage: '',
+  skipDeps: false,
   redirectError: {
     error: '',
     errorReason: ''
@@ -33,10 +35,13 @@ export const slice = createSlice({
       state.redirectError.error = action.payload.error;
       state.redirectError.errorReason = action.payload.errorReason;
     },
+    skipDeps: (state, action: PayloadAction<boolean>) => {
+      state.skipDeps = action.payload;
+    },
   },
 });
 
-export const { errorMessage, redirectError } = slice.actions;
+export const { errorMessage, redirectError, skipDeps } = slice.actions;
 
 export const setErrorMessage = (msg: string): AppThunk => dispatch => {
   dispatch(errorMessage(msg));
@@ -46,8 +51,13 @@ export const setRedirectError = (error: string, errorReason: string): AppThunk =
   dispatch(redirectError({ error, errorReason }));
 };
 
+export const setSkipDeps = (skip: boolean): AppThunk => dispatch => {
+  dispatch(skipDeps(skip));
+};
+
 export const selectErrorMessage = (state: RootState) => state.hatLogin.errorMessage;
 export const selectRedirectError = (state: RootState) => state.hatLogin.redirectError;
+export const selectSkipDeps = (state: RootState) => state.hatLogin.skipDeps;
 
 export const onTermsAgreed = (parentAppId: string): AppThunk => async dispatch => {
   dispatch(setErrorMessage(''));


### PR DESCRIPTION
- /hatlogin now accepts a query parameter to skip the data plug enablement process. Developers can use the "skip_deps" parameter and if is set to `true` the user will not get redirected to connect the plug. 