### PR TITLE
Add Application Details components and page.

### DIFF
--- a/src/app/AppRouter.tsx
+++ b/src/app/AppRouter.tsx
@@ -55,7 +55,15 @@ const HatApplications = React.lazy(
   () =>
     import(
       /* webpackChunkName: "hat_applications" */
-      '../features/applications'
+      '../features/applications/HatApplications'
+    ),
+);
+
+const HatApplicationDetails = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "hat_application_details" */
+      '../features/applications/ApplicationDetails'
     ),
 );
 
@@ -79,8 +87,12 @@ const AppRouter = () => (
         <Route path="/auth/change-password/:resetToken" component={AuthChangePassword} />
         <Route path="/auth/verify-email/:verifyToken" component={AuthVerifyEmail} />
 
-        <PrivateRoute path={'/applications'}>
+        <PrivateRoute exact path={'/applications'}>
           <HatApplications />
+        </PrivateRoute>
+
+        <PrivateRoute exact path={'/applications/:appId'}>
+          <HatApplicationDetails />
         </PrivateRoute>
 
         <PrivateRoute path={'/hatlogin'}>

--- a/src/assets/styles/_branding.scss
+++ b/src/assets/styles/_branding.scss
@@ -5,21 +5,23 @@ $font-auth-secondary: 'Poppins', sans-serif;
 $app-dark-tone: #4a556b;
 $app-accent-color: #6297b1;
 $app-background-color: white;
+$app-failing-color: #e45151;
+$app-update-color: #f5a623;
 
-$ds-accent-color: #20154E;
+$ds-accent-color: #20154e;
 
 $button-accent-color: $app-accent-color;
 $button-accent-text-color: white;
 $button-accent-disabled-color: #d2d5da;
 $button-transparent-color: transparent;
 
-$progress-bar-weak: #E45151;
-$progress-bar-average: #F5A623;
-$progress-bar-strong: #64B467;
-$progress-bar-background-color: #D8D8D8;
+$progress-bar-weak: $app-failing-color;
+$progress-bar-average: $app-update-color;
+$progress-bar-strong: #64b467;
+$progress-bar-background-color: #d8d8d8;
 
-$bp-largest: 75em;     // 1200px
-$bp-large: 68.75em;    // 1100px
-$bp-medium: 56.25em;   // 900px
-$bp-small: 37.5em;     // 600px
+$bp-largest: 75em; // 1200px
+$bp-large: 68.75em; // 1100px
+$bp-medium: 56.25em; // 900px
+$bp-small: 37.5em; // 600px
 $bp-smallest: 31.25em; // 500px

--- a/src/assets/styles/_headers.scss
+++ b/src/assets/styles/_headers.scss
@@ -111,3 +111,65 @@ header {
     }
   }
 }
+
+.details-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 155px;
+  position: relative;
+  height: 234px;
+  width: 100%;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-color: #4a556b;
+
+  &:before {
+    position: absolute;
+    content: ' ';
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .details-header-toolbar {
+    background-color: transparent;
+    display: flex;
+    width: 100%;
+    height: 64px;
+    justify-content: flex-end;
+    align-items: center;
+    z-index: 1;
+    padding: 0 2rem;
+  }
+
+  .details-header-card {
+    margin-bottom: -155px;
+    padding: 0 2em;
+    padding-bottom: 20px;
+    border-radius: 4px;
+    width: 90%;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #fff;
+    box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
+
+    .details-header-logo-wrapper {
+      margin-top: -50px;
+      background-color: white;
+      padding: 6px;
+      border-radius: 50%;
+
+      .details-header-logo {
+        height: 100px;
+        width: 100px;
+        border-radius: 50%;
+      }
+    }
+  }
+}

--- a/src/components/headers/DetailsHeader/DetailsHeader.test.tsx
+++ b/src/components/headers/DetailsHeader/DetailsHeader.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+import DetailsHeader from './DetailsHeader';
+
+describe('Details Header', () => {
+  test('renders the details header without error', () => {
+    render(
+      <DetailsHeader logoSrc="testSrc" logoAltText="A Test Alt Text">
+        <h1>Test</h1>
+      </DetailsHeader>,
+    );
+
+    expect(screen.getByText('Test')).toBeInTheDocument();
+    expect(screen.getByAltText('A Test Alt Text')).toBeInTheDocument();
+  });
+});

--- a/src/components/headers/DetailsHeader/DetailsHeader.tsx
+++ b/src/components/headers/DetailsHeader/DetailsHeader.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+type DetailsHeaderProps = {
+  logoSrc: string;
+  logoAltText: string;
+  toolbarActions?: React.ReactNode;
+  backgroundColor?: string;
+};
+
+const DetailsHeader: React.FC<DetailsHeaderProps> = ({
+  logoSrc,
+  logoAltText,
+  toolbarActions,
+  backgroundColor,
+  children,
+}) => {
+  return (
+    <div className="details-header" style={{ backgroundColor }}>
+      <div className="details-header-toolbar">{toolbarActions}</div>
+
+      <div className="details-header-card">
+        <div className="details-header-logo-wrapper">
+          <img className="details-header-logo" src={logoSrc} alt={logoAltText} />
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default DetailsHeader;

--- a/src/components/lists/HatApplication.scss
+++ b/src/components/lists/HatApplication.scss
@@ -1,6 +1,0 @@
-.hat-app-list {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  background-color: #fafafa;
-}

--- a/src/features/applications/ApplicationDetails.test.tsx
+++ b/src/features/applications/ApplicationDetails.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { createMemoryHistory } from 'history';
+import { Router, Route } from 'react-router-dom';
+
+import applicationsSlice from './applicationsSlice';
+import TEST_HAT_APPLICATION from '../../testData/HatApplications';
+import ApplicationDetails from './ApplicationDetails';
+
+export const store = configureStore({
+  reducer: {
+    applications: applicationsSlice,
+  },
+  preloadedState: {
+    applications: {
+      applications: [TEST_HAT_APPLICATION],
+    },
+  },
+});
+
+describe('Hat Application Details', () => {
+  test('renders and displays the correct hat application details', () => {
+    const history = createMemoryHistory({ initialEntries: ['/applications/1'] });
+
+    render(
+      <Router history={history}>
+        <Route path="/applications/:appId">
+          <Provider store={store}>
+            <ApplicationDetails />
+          </Provider>
+        </Route>
+      </Router>,
+    );
+
+    expect(screen.getByText('Test Application')).toBeInTheDocument();
+    expect(screen.getByText('more_horiz')).toBeInTheDocument();
+    expect(screen.getByText('Connect')).toBeInTheDocument();
+    expect(screen.getByAltText('HAT Application Logo')).toBeInTheDocument();
+  });
+
+  test('the correct location is called when the user clicks on the status button', () => {
+    const history = createMemoryHistory({ initialEntries: ['/applications/1'] });
+
+    render(
+      <Router history={history}>
+        <Route path="/applications/:appId">
+          <Provider store={store}>
+            <ApplicationDetails />
+          </Provider>
+        </Route>
+      </Router>,
+    );
+
+    fireEvent.click(screen.getByText('exit_to_app'));
+
+    expect(history.location.pathname).toEqual('/auth/oauth');
+    expect(history.location.search).toEqual(
+      '?application_id=1&fallback=http://localhost/&redirect_uri=%3Fredirect=http://localhost/',
+    );
+  });
+});

--- a/src/features/applications/ApplicationDetails.tsx
+++ b/src/features/applications/ApplicationDetails.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useHistory, useParams } from 'react-router-dom';
+
+import DetailsHeader from '../../components/headers/DetailsHeader/DetailsHeader';
+import FormatMessage from '../messages/FormatMessage';
+import { getApplicationById, selectApplicationById } from './applicationsSlice';
+import './HatApplication.scss';
+import { getStatusIcon, getAppStatus } from './helper';
+
+const AppDetailsToolbarActions = () => <i className="material-icons details-close">more_horiz</i>;
+
+const HatApplicationDetails: React.FC = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const { appId } = useParams<{ appId: string }>();
+  const app = useSelector(selectApplicationById(appId));
+
+  useEffect(() => {
+    if (!app) dispatch(getApplicationById(appId));
+  }, [dispatch, app, appId]);
+
+  if (!app) return null;
+
+  const onAppStatusClick = () => {
+    const { id, setup } = app.application;
+    const redirectRumpel = window.location.href;
+    const redirectUrl = setup.url || setup.iosUrl || '';
+
+    history.push(
+      `/auth/oauth?` +
+        `application_id=${id}&fallback=${redirectRumpel}&redirect_uri=${redirectUrl}%3Fredirect=${redirectRumpel}`,
+    );
+  };
+
+  return (
+    <DetailsHeader
+      logoSrc={app.application.info.graphics.logo.normal}
+      logoAltText="HAT Application Logo"
+      toolbarActions={<AppDetailsToolbarActions />}
+      backgroundColor="#2b313d"
+    >
+      <div className="app-rating-wrapper">
+        <div className="app-rating">
+          <span className="app-rating-highlighted">{app.application.info.rating.score}</span>
+        </div>
+      </div>
+
+      <h3 className="app-details-header-title">{app.application.info.name}</h3>
+      <div className="app-details-header-headline">
+        <FormatMessage id="ds.hat.application.details.rated" /> {app.application.info.rating.score}
+      </div>
+
+      <a href="https://resources.dataswift.io/contents/4a9f5153-7d52-4b79-8eb1-e570aa331291" className="app-link">
+        <FormatMessage id="ds.hat.application.details.learn" />
+      </a>
+
+      <div onClick={onAppStatusClick} className={`app-details-status ${getAppStatus(app)} link-button`}>
+        <i className="material-icons details-button-icon">{getStatusIcon(app)}</i>
+        Connect
+      </div>
+    </DetailsHeader>
+  );
+};
+
+export default HatApplicationDetails;

--- a/src/features/applications/ApplicationList.test.tsx
+++ b/src/features/applications/ApplicationList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
 
@@ -35,11 +35,11 @@ describe('HAT Application List', () => {
 
   test('the correct icon text is displayed for each hat application status', () => {
     const { rerender } = render(<ApplicationList hatApps={[TEST_HAT_APPLICATION]} onAppClick={jest.fn()} />);
-    expect(screen.getByText('check_circle')).toBeInTheDocument();
+    expect(screen.getByText('exit_to_app')).toBeInTheDocument();
 
     const needsUpdatingApp = { ...TEST_HAT_APPLICATION, needsUpdating: true };
     rerender(<ApplicationList hatApps={[needsUpdatingApp]} onAppClick={jest.fn()} />);
-    expect(screen.getByText('sync_problem')).toBeInTheDocument();
+    expect(screen.getByText('refresh')).toBeInTheDocument();
 
     const untouchedApp = { ...TEST_HAT_APPLICATION, enabled: false, active: false };
     rerender(<ApplicationList hatApps={[untouchedApp]} onAppClick={jest.fn()} />);
@@ -71,6 +71,6 @@ describe('HAT Application List', () => {
       },
     };
     rerender(<ApplicationList hatApps={[goToApp]} onAppClick={jest.fn()} />);
-    expect(screen.getByText('check_circle')).toBeInTheDocument();
+    expect(screen.getByText('exit_to_app')).toBeInTheDocument();
   });
 });

--- a/src/features/applications/ApplicationList.tsx
+++ b/src/features/applications/ApplicationList.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 
 import { HatApplication } from '@dataswift/hat-js/lib/interfaces/hat-application.interface';
-import Card from '../Card/Card';
+import Card from '../../components/Card/Card';
 import { getStatusIcon } from './helper';
 
 import './HatApplication.scss';

--- a/src/features/applications/HatApplication.scss
+++ b/src/features/applications/HatApplication.scss
@@ -1,0 +1,146 @@
+@import '../../assets/styles/branding';
+
+.hat-app-list {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  background-color: #fafafa;
+}
+
+.app-rating-wrapper {
+  position: relative;
+  margin-top: -20px;
+  background-color: white;
+  padding: 6px;
+  border-radius: 4px;
+
+  &:before {
+    content: ' ';
+    position: absolute;
+    top: -10px;
+    border: solid transparent;
+    border-width: 5px 35px;
+    border-bottom-color: white;
+    border-radius: 4px;
+  }
+
+  .app-rating {
+    position: relative;
+    background-color: #dfc586;
+    font-size: 12px;
+    color: white;
+    text-align: center;
+    width: 70px;
+    padding: 2px 0;
+
+    &:before {
+      content: ' ';
+      position: absolute;
+      top: -10px;
+      left: 0;
+      border: solid transparent;
+      border-width: 5px 35px;
+      border-bottom-color: #dfc586;
+    }
+
+    &.red {
+      background-color: #d36969;
+
+      &:before {
+        border-bottom-color: #d36969;
+      }
+    }
+
+    &.green {
+      background-color: #7db774;
+
+      &:before {
+        border-bottom-color: #7db774;
+      }
+    }
+
+    &.gold {
+      background-color: #dfc586;
+
+      &:before {
+        border-bottom-color: #dfc586;
+      }
+    }
+
+    &-highlighted {
+      font-weight: bold;
+    }
+
+    &-italicized {
+      font-style: italic;
+    }
+  }
+}
+
+.app-link {
+  color: #6297b1;
+  font-size: 13px;
+  font-weight: bold;
+  padding-bottom: 16px;
+  text-decoration: none;
+}
+
+.app-details-header-title {
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  color: $app-dark-tone;
+}
+
+.app-details-header-headline {
+  font-size: 13px;
+  color: #9a9a9a;
+  line-height: 1.38;
+  font-style: italic;
+}
+
+.app-details-status {
+  display: flex;
+  align-items: center;
+  border: none;
+  text-decoration: none;
+  margin-top: 5px;
+  margin-bottom: 20px;
+  padding: 5px 20px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-size: 14px;
+  font-weight: bold;
+  color: white;
+  line-height: 36px;
+
+  &.running {
+    border: 1px solid $app-accent-color;
+    background-color: transparent;
+    color: $app-accent-color;
+  }
+  &.fetching {
+    color: $app-accent-color;
+  }
+  &.failing {
+    background-color: $app-failing-color;
+  }
+  &.untouched,
+  &.goto {
+    background-color: $app-accent-color;
+  }
+
+  &.update {
+    background-color: $app-update-color;
+  }
+
+  .details-button-icon {
+    margin-right: 5px;
+  }
+}
+
+.details-close {
+  color: white;
+  cursor: pointer;
+}

--- a/src/features/applications/HatApplications.test.tsx
+++ b/src/features/applications/HatApplications.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router';
+
+import HatApplications from './HatApplications';
+import applicationsSlice from './applicationsSlice';
+
+import { configureStore } from '@reduxjs/toolkit';
+import TEST_HAT_APPLICATION from '../../testData/HatApplications';
+
+export const store = configureStore({
+  reducer: {
+    applications: applicationsSlice,
+  },
+  preloadedState: {
+    applications: {
+      applications: [TEST_HAT_APPLICATION],
+    },
+  },
+});
+
+describe('Hat Application page tests', () => {
+  test('renders a list of items that navigates the user when clicked', () => {
+    const history = createMemoryHistory({ initialEntries: ['/applications'] });
+
+    render(
+      <Router history={history}>
+        <Provider store={store}>
+          <HatApplications />
+        </Provider>
+      </Router>,
+    );
+
+    expect(history.location.pathname).toEqual('/applications');
+    const application = screen.getByText('Test Application');
+    expect(application).toBeInTheDocument();
+
+    fireEvent.click(application);
+
+    expect(history.location.pathname).toEqual('/applications/1');
+  });
+});

--- a/src/features/applications/HatApplications.tsx
+++ b/src/features/applications/HatApplications.tsx
@@ -1,12 +1,14 @@
-import * as React from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router';
 
 import TileHeader from '../../components/headers/TileHeader/TileHeader';
-import ApplicationList from '../../components/lists/ApplicationList';
+import ApplicationList from './ApplicationList';
 import { getApplications, selectApplications } from './applicationsSlice';
 
 const HATApplications: React.FC = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const apps = useSelector(selectApplications);
 
   React.useEffect(() => {
@@ -14,7 +16,7 @@ const HATApplications: React.FC = () => {
   }, [dispatch]);
 
   const onAppClick = (appId: string) => {
-    // TODO add navigation when page exists.
+    history.push(`/applications/${appId}`);
   };
 
   return (

--- a/src/features/applications/helper.ts
+++ b/src/features/applications/helper.ts
@@ -14,9 +14,9 @@ enum HatApplicationKind {
   APP = 'App',
 }
 
-type HatAppStatusIcons = 'check_circle' | 'sync' | 'sync_problem' | 'add_circle_outline';
+type HatAppStatusIcons = 'check_circle' | 'sync' | 'sync_problem' | 'add_circle_outline' | 'refresh' | 'exit_to_app';
 
-const getAppStatus = (app: HatApplication): HatApplicationStatus => {
+export const getAppStatus = (app: HatApplication): HatApplicationStatus => {
   const { setup, enabled, active, needsUpdating, mostRecentData } = app;
   const kind = app.application.kind.kind;
 
@@ -34,13 +34,15 @@ const getAppStatus = (app: HatApplication): HatApplicationStatus => {
 export const getStatusIcon = (app: HatApplication): HatAppStatusIcons => {
   switch (getAppStatus(app)) {
     case HatApplicationStatus.RUNNING:
-    case HatApplicationStatus.GOTO:
       return 'check_circle';
+    case HatApplicationStatus.GOTO:
+      return 'exit_to_app';
     case HatApplicationStatus.FETCHING:
       return 'sync';
     case HatApplicationStatus.FAILING:
-    case HatApplicationStatus.UPDATE:
       return 'sync_problem';
+    case HatApplicationStatus.UPDATE:
+      return 'refresh';
     default:
       return 'add_circle_outline';
   }

--- a/src/features/applications/index.ts
+++ b/src/features/applications/index.ts
@@ -1,3 +1,0 @@
-import HatApplications from './HatApplications';
-
-export default HatApplications;

--- a/src/services/HatClientService.ts
+++ b/src/services/HatClientService.ts
@@ -1,9 +1,10 @@
 import { HatClient } from '@dataswift/hat-js';
-import { get, post } from './BackendService';
+import { HatApplicationContent } from 'hmi/dist/interfaces/hat-application.interface';
 import { HatApplication } from '@dataswift/hat-js/lib/interfaces/hat-application.interface';
 import { HatTokenValidation } from '@dataswift/hat-js/lib/utils/HatTokenValidation';
+
+import { get, post } from './BackendService';
 import { HatTool } from '../features/tools/hat-tool.interface';
-import { HatApplicationContent } from 'hmi/dist/interfaces/hat-application.interface';
 
 export class HatClientService {
   private readonly pathPrefix = '/api/v2.6';

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -37,5 +37,7 @@
   "ds.auth.verifyEmail.title": "Create a password",
   "ds.auth.verifyEmail.success.title": "The password to your Personal Data Account has been created.",
   "ds.hat.applications.header.title": "HAT Applications",
-  "ds.hat.applications.header.description": "HAT apps are integrated with you HAT data to give you great services"
+  "ds.hat.applications.header.description": "HAT apps are integrated with you HAT data to give you great services",
+  "ds.hat.application.details.rated": "This app is rated",
+  "ds.hat.application.details.learn": "Learn More"
 }


### PR DESCRIPTION
Added: New page which will display the details of a HAT application.
Currently, only the header is displayed.

Added: New Application Details header component.

Added: New functionality to the application slice to allow for
fetching a single hat application - either from redux state, or
if that fails, from an API call.

Removed: `components/list` contained the hat application list
component. This has been moved to `features/applications` as the
list is specific to that feature.

Changed: Some style colours have been lifted up into the branding
scss file.