### PR TITLE
DSE-899 Refactor HMI's loading guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "date-fns": "^2.12.0",
-    "hmi": "git+ssh://git@github.com:dataswift/hmi-react.git#v0.2.12-RC-2",
+    "hmi": "git+ssh://git@github.com:dataswift/hmi-react.git#v0.2.12",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.19",
     "lodash-es": "^4.17.15",

--- a/src/features/hat-login/helpers.test.ts
+++ b/src/features/hat-login/helpers.test.ts
@@ -1,0 +1,102 @@
+import { isHmiLoading } from "./helpers";
+import TEST_HAT_APPLICATION from "../../testData/HatApplications";
+import { HatApplication } from "@dataswift/hat-js/lib/interfaces/hat-application.interface";
+import TEST_DATA_PLUG from "../../testData/DataPlug";
+import TEST_HAT_TOOL from "../../testData/Tool";
+
+describe('HmiLogin Helper', () => {
+  it('is loading when the app is active and doesn\'t need updating', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = true;
+    testApp.needsUpdating = false;
+    testApp.enabled = true;
+    testApp.setup = true;
+
+    expect(isHmiLoading(testApp)).toEqual(true);
+  });
+
+  it('is not loading when the app needs updating', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = true;
+    testApp.needsUpdating = true;
+    testApp.enabled = true;
+    testApp.setup = true;
+      
+    expect(isHmiLoading(testApp)).toEqual(false);
+  });
+
+  it('it returns false when the app is not active or needs updating', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = false;
+    testApp.needsUpdating = false;
+    testApp.enabled = true;
+    testApp.setup = true;
+
+    expect(isHmiLoading(testApp)).toEqual(false);
+  });
+
+  it('it returns false when all the app flags are false', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = false;
+    testApp.needsUpdating = false;
+    testApp.enabled = false;
+    testApp.setup = false;
+
+    expect(isHmiLoading(testApp)).toEqual(false);
+  });
+
+  it('is loading when all the app\'s dependencies are ready and app is active', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = true;
+    testApp.needsUpdating = false;
+    testApp.enabled = false;
+    testApp.setup = false;
+    testApp.application.dependencies = { plugs: ['2'], tools: [], contracts: [] };
+
+    expect(isHmiLoading(testApp, [TEST_DATA_PLUG, TEST_HAT_APPLICATION])).toEqual(true);
+  });
+
+  it('doesn\'t loading when all the app\'s dependencies are empty arrays', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = false;
+    testApp.needsUpdating = false;
+    testApp.enabled = false;
+    testApp.setup = false;
+    testApp.application.dependencies = { plugs: [], tools: [], contracts: [] };
+
+    expect(isHmiLoading(testApp, [TEST_DATA_PLUG, TEST_HAT_APPLICATION])).toEqual(false);
+  });
+
+  it('is not loading when all the app\'s dependencies are ready (tools)', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = false;
+    testApp.needsUpdating = false;
+    testApp.enabled = false;
+    testApp.setup = false;
+    testApp.application.dependencies = { plugs: [], tools: ['test-feed-counter'], contracts: [] };
+
+    expect(isHmiLoading(testApp, [TEST_DATA_PLUG, TEST_HAT_APPLICATION], [TEST_HAT_TOOL])).toEqual(false);
+  });
+
+  it('is loading when all the app\'s tool dependencies are not ready', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = false;
+    testApp.needsUpdating = false;
+    testApp.enabled = false;
+    testApp.setup = false;
+    testApp.application.dependencies = { plugs: [], tools: ['different-tool-id'], contracts: [] };
+
+    expect(isHmiLoading(testApp, [TEST_DATA_PLUG, TEST_HAT_APPLICATION], [TEST_HAT_TOOL])).toEqual(true);
+  });
+
+  it('is not loading when an app has dependencies and needs updating', () => {
+    const testApp = JSON.parse(JSON.stringify(TEST_HAT_APPLICATION)) as HatApplication;
+    testApp.active = true;
+    testApp.needsUpdating = true;
+    testApp.enabled = false;
+    testApp.setup = false;
+    testApp.application.dependencies = { plugs: [], tools: ['test-feed-counter'], contracts: [] };
+
+    expect(isHmiLoading(testApp, [TEST_DATA_PLUG, TEST_HAT_APPLICATION], [TEST_HAT_TOOL])).toEqual(false);
+  });
+});

--- a/src/features/hat-login/helpers.ts
+++ b/src/features/hat-login/helpers.ts
@@ -1,0 +1,34 @@
+import { HatApplication } from "@dataswift/hat-js/lib/interfaces/hat-application.interface";
+import { HatTool } from "../tools/hat-tool.interface";
+
+export const isHmiLoading = (app: HatApplication, dependencyPlugs?: HatApplication[], dependencyTools?: HatTool[]) => {
+  // In case an app is active and doesn't need updating, we need to display the loading screen to the user.
+  const isParentAppActive = app.active && !app.needsUpdating;
+
+  // Check if the app has 1 or more plug dependencies.
+  const hasPlugDependencies = app.application.dependencies && app.application.dependencies?.plugs.length > 0;
+  // Check if the app has 1 or more tool dependencies.
+  const hasToolDependencies = app.application.dependencies && app.application.dependencies?.tools.length > 0;
+
+  // Search for the app's dependency plugs and if they are currently available.
+  const foundDependencyPlugs =
+      dependencyPlugs?.filter(a => app.application.dependencies?.plugs?.indexOf(a.application.id) !== -1);
+
+  // Check if the data plugs and app's dependency plugs are ready.
+  const isDependencyPlugsReady = app.application.dependencies?.plugs &&
+      foundDependencyPlugs?.length ===  app.application.dependencies?.plugs.length;
+
+  // Search for the app's dependency tools and if they are currently available.
+  const foundDependencyTools =
+      dependencyTools?.filter(t => app.application.dependencies?.tools?.indexOf(t.id) !== -1);
+
+  // Check if the tools and app's dependency tools are ready.
+  const isDependencyToolsReady = app.application.dependencies?.tools &&
+      foundDependencyTools?.length ===  app.application.dependencies?.tools.length;
+
+  return (
+    isParentAppActive ||
+    (hasPlugDependencies && !isDependencyPlugsReady) ||
+    (hasToolDependencies && !isDependencyToolsReady)
+  );
+};

--- a/src/features/hmi/hmiSlice.ts
+++ b/src/features/hmi/hmiSlice.ts
@@ -23,7 +23,7 @@ export const slice = createSlice({
       state.parentApp = action.payload;
     },
     dependencyApps: (state, action: PayloadAction<HatApplication[]>) => {
-      state.dependencyApps.push(...action.payload);
+      state.dependencyApps = action.payload;
     },
     dependencyTools: (state, action: PayloadAction<HatTool[]>) => {
       state.dependencyTools = action.payload;

--- a/src/features/oauth/OauthPermissions.tsx
+++ b/src/features/oauth/OauthPermissions.tsx
@@ -6,6 +6,7 @@ import { HmiType, HmiV2 } from "hmi";
 import { onTermsAgreed, onTermsDeclined, selectErrorMessage, setRedirectError } from "../hat-login/hatLoginSlice";
 import { NotificationBanner } from "../../components/banners/NotificationBanner/NotificationBanner";
 import { selectLanguage } from "../language/languageSlice";
+import { isHmiLoading } from "../hat-login/helpers";
 
 const OauthPermissions: React.FC = () => {
   const hatName = window.location.host;
@@ -20,10 +21,7 @@ const OauthPermissions: React.FC = () => {
     dispatch(setRedirectError('hat_exception', 'enabling_application_failed'));
   };
 
-  if ((!parentApp || (parentApp.active && !parentApp.needsUpdating)) || (parentApp.application.dependencies &&
-      parentApp.application.dependencies.plugs?.length !== dependencyApps.length) ||
-      (parentApp.application.dependencies &&
-          parentApp.application.dependencies.tools?.length !== dependencyTools.length)) {
+  if (!parentApp || isHmiLoading(parentApp, dependencyApps, dependencyTools)) {
     return <LoadingSpinner loadingText={'Loading permissions...'}/>;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5912,9 +5912,9 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-"hmi@git+ssh://git@github.com:dataswift/hmi-react.git#v0.2.12-RC-2":
+"hmi@git+ssh://git@github.com:dataswift/hmi-react.git#v0.2.12":
   version "0.2.12"
-  resolved "git+ssh://git@github.com:dataswift/hmi-react.git#94196a12d1dce60174eeea3ab3f31dd599a781e0"
+  resolved "git+ssh://git@github.com:dataswift/hmi-react.git#0d43e23179094bdb8ede888f2497979c4028b066"
   dependencies:
     components "^0.1.0"
     context "^0.0.1"


### PR DESCRIPTION
## Description
- Refactoring on Oauth's guard for displaying the loading screen.
- Add tests to ensure that this guard is working as expected.

## Why
In the oauth flow, we do some checks and displaying either the HMI or a loading screen.
During a testing on internal staging, I found an issue with an extra parameter that we were checking.
Instead of fixing this issue, I decided to do some refactoring instead as this condition was getting bigger and bigger.

## AC
- Fix the issue that let the loading screen loading forever in internal staging.
- Do refactoring in the guard condition.

## Source
https://dswift.atlassian.net/browse/DSE-899

## Type
- [x] Bug Fix
- [ ] Feature Addition 
- [x] Refactor
- [ ] HotFix

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
