### PR TITLE
DAS-572 Fixed the issue with dataswift.io login

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.11",
   "private": true,
   "dependencies": {
-    "@dataswift/hat-js": "^0.4.0",
+    "@dataswift/hat-js": "^0.5.0",
     "@dataswift/shared": "v0.0.3",
     "@material-ui/core": "^4.11.3",
     "@reduxjs/toolkit": "^1.5.1",

--- a/src/features/hat-login/HatLoginBuildRedirect.tsx
+++ b/src/features/hat-login/HatLoginBuildRedirect.tsx
@@ -36,6 +36,7 @@ const HatLoginBuildRedirect: React.FC<Props> = (props) => {
 
       const isInternal = internal === 'true';
       const redirectParam = redirect_uri || redirect;
+      const redirectParamDecoded = decodeURIComponent(redirectParam || '');
 
       if (isInternal) {
         window.location.href = redirectParam || '';
@@ -49,10 +50,7 @@ const HatLoginBuildRedirect: React.FC<Props> = (props) => {
             const { accessToken } = resAppLogin.parsedBody;
             const setup = app.application.setup;
 
-            // TODO Change this logic to the new validRedirectUris field
-            const isRedirectUrlValid =
-              [setup.url, setup.iosUrl, setup.androidUrl, setup.testingUrl].indexOf(decodeURI(redirectParam || '')) !==
-              -1;
+            const isRedirectUrlValid = setup.validRedirectUris.includes(redirectParamDecoded);
 
             const attemptedSetup = {
               applicationId: app.application.id,
@@ -66,11 +64,12 @@ const HatLoginBuildRedirect: React.FC<Props> = (props) => {
             // The problem is that the dataswift.io page has no idea what to do with the token and
             // users are stuck there. With this hack users are being redirected
             // back to their PDA Dashboard which is the intended behaviour.
-            const isDataswiftWebsite = redirectParam?.includes('www.dataswift.io%2Fsign-up-login');
-            const paramTokem = redirectParam?.indexOf('?') !== -1 ? '&' : '?';
+            const isDataswiftWebsite = redirectParamDecoded?.includes('www.dataswift.io/sign-up-login');
+
+            const paramTokem = redirectParam?.includes('?') ? '&' : '?';
 
             const url = isDataswiftWebsite
-              ? window.location.origin + '/#/feed'
+              ? window.location.origin + '/feed'
               : `${redirectParam?.replace('#', '%23')}${paramTokem}token=${accessToken}`;
 
             if (isRedirectUrlValid) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,10 +1182,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@dataswift/hat-js@^0.4.0":
-  version "0.4.0"
-  resolved "https://npm.pkg.github.com/download/@dataswift/hat-js/v0.4.0/026ca20e12c9351690216a8f3bc2480b0da4e7c9cefc73db93222091c15ca1e5#04702c32a23f469b6124f7a398eb9a0aef18a2d0"
-  integrity sha512-upCn5yETywd0k1sLmWYjntvkRmpmWKusjfV+YoOQ2qedLGMwjfHywuBsppzlNizbP/RWyZoGjN2xIuIjeYO+mw==
+"@dataswift/hat-js@^0.5.0":
+  version "0.5.0"
+  resolved "https://npm.pkg.github.com/download/@dataswift/hat-js/v0.5.0/c5b0002a67ae907aace5c796ebd40a4b12fc202cf34e99c14ed9c55861f9a44d#37d99ef7f56bfb04c448adbf9bc110bb73655fea"
+  integrity sha512-vd745FEnbiUpc7C8iElGeJSeiDNhpER5fypIxTgQMkpzsPARDHDEurTcWRX5RiNixzuWNT3ViF6iK8IvrjualQ==
   dependencies:
     cross-fetch "^3.1.2"
     jwt-decode "^3.1.2"


### PR DESCRIPTION
## Description
This PR fixes the logging in issue from dataswift.io

## AC
User story: 

Using chrome or firefox, go to dataswift.io page. Log in to your hat through there. If you are already logged in, you are being redirected back to dataswift.io. If you are NOT logged it then the flow is correct and you are redirected to your PDA.

You always are redirected back to your PDA. No matter if you are logged in already or not.

Note: Safari works perfectly.

## Source
https://dswift.atlassian.net/browse/DAS-572

## Type
- [x] Bug Fix
- [ ] Feature Addition 
- [ ] Refactor
- [ ] HotFix

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
